### PR TITLE
Consider void segment account

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/analytics "0.6.3"
+(defproject clanhr/analytics "1.0.0"
   :description "ClanHR specific analytics"
   :url "https://github.com/clanhr/analytics"
   :license {:name "Eclipse Public License"

--- a/src/clanhr/analytics/core.clj
+++ b/src/clanhr/analytics/core.clj
@@ -5,7 +5,12 @@
 (defn- token
   "Access token for segment.io"
   []
-  (or (env :clanhr-segment-token) "o8CiVtd14K65kWGl4sHHEdzk5GbN7NCD"))
+  (env :clanhr-segment-token))
+
+(defn- test-token
+  "Access void token for segment.io"
+  []
+  (or (env :clanhr-segment-void-token) "IBqHKDwieBPjkZMtqhYbxStKc0KziG4M"))
 
 (defn- logger
   "Logs events"
@@ -25,6 +30,21 @@
                     content
                     (analytics/initialize (token))))))
 
+(def ^:private test-client (atom nil))
+(defn- get-test-client
+  []
+  (swap! test-client (fn [content]
+                      (if content
+                        content
+                        (analytics/initialize (test-token))))))
+
+(defn get-user-client
+  "Gets the current client to use, based on if it's a test"
+  [test?]
+  (if test?
+    (get-test-client)
+    (get-client)))
+
 (defn- build-traits
   "Prepares traits with required fields"
   [traits user-id]
@@ -34,16 +54,20 @@
 
 (defn identify
   "Identifies a user and sets user traits"
-  [user-id traits]
+  [user-id traits test?]
   (let [traits (build-traits traits user-id)]
-    (analytics/identify (get-client)
+    (analytics/identify (get-user-client test?)
                         user-id
                         traits
                         (build-options user-id "identify" traits))))
 
 (defn track
   "Tracks an event for a given user"
-  ([user-id event-name]
-   (track user-id event-name {}))
-  ([user-id event-name traits]
-   (analytics/track (get-client) user-id event-name traits (build-options user-id event-name traits))))
+  ([user-id event-name test?]
+   (track user-id event-name {} test?))
+  ([user-id event-name traits test?]
+   (analytics/track (get-user-client test?)
+                    user-id
+                    event-name
+                    traits
+                    (build-options user-id event-name traits))))

--- a/test/clanhr/analytics/core_test.clj
+++ b/test/clanhr/analytics/core_test.clj
@@ -5,10 +5,10 @@
 (def user-id "clojure-test")
 
 (deftest smoke-test-identify
-  (core/identify user-id {:name "Clojure Test"})
-  (core/identify user-id {:userId "Clojure Test"})
-  (core/identify user-id nil)
-  (core/identify user-id {}))
+  (core/identify user-id {:name "Clojure Test"} true)
+  (core/identify user-id {:userId "Clojure Test"} true)
+  (core/identify user-id nil true)
+  (core/identify user-id {} true))
 
 (deftest smoke-test-track
-  (core/track user-id "Clojure unit test"))
+  (core/track user-id "Clojure unit test" true))


### PR DESCRIPTION
To not pollute segment's main account with dummy test data, this lib will
choose from two segment keys and when in tests, send data to a void segment
account.
