### PR TITLE
Add make-alias

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/analytics "1.5.0"
+(defproject clanhr/analytics "1.6.0"
   :description "ClanHR specific analytics"
   :url "https://github.com/clanhr/analytics"
   :license {:name "Eclipse Public License"

--- a/src/clanhr/analytics/core.clj
+++ b/src/clanhr/analytics/core.clj
@@ -63,6 +63,11 @@
                         traits
                         (build-options user-id "identify" traits))))
 
+(defn make-alias
+  "Marks two user-ids as the same identity"
+  [user1 user2 test?]
+  (analytics/make-alias (get-user-client test?) user1 user2))
+
 (defn track
   "Tracks an event for a given user"
   ([user-id event-name test?]

--- a/test/clanhr/analytics/core_test.clj
+++ b/test/clanhr/analytics/core_test.clj
@@ -10,5 +10,8 @@
   (core/identify user-id nil true)
   (core/identify user-id {} true))
 
+(deftest smoke-test-make-alias
+  (core/make-alias "id1" "id2" true))
+
 (deftest smoke-test-track
   (core/track user-id "Clojure unit test" true))


### PR DESCRIPTION
Add `make-alias` to the segment wrapper, that allows merge between two
user ids.
