### PR TITLE
Add track fn to metrics

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/analytics "1.7.1"
+(defproject clanhr/analytics "1.8.0"
   :description "ClanHR specific analytics"
   :url "https://github.com/clanhr/analytics"
   :license {:name "Eclipse Public License"

--- a/src/clanhr/analytics/metrics.clj
+++ b/src/clanhr/analytics/metrics.clj
@@ -94,6 +94,17 @@
             1
             entity-name))
 
+(defn track
+  "Tracks an event with a value"
+  ([event-name source]
+   (track event-name source 1))
+  ([event-name source event-value]
+   (register (env :clanhr-env)
+             source
+             (str (env :clanhr-env) "." event-name)
+             event-value
+             (str event-name " " source))))
+
 (defn postgres-request
   "Tracks a postgres query"
   [env-name source elapsed query]

--- a/test/clanhr/analytics/metrics_test.clj
+++ b/test/clanhr/analytics/metrics_test.clj
@@ -18,3 +18,7 @@
   (metrics/new-entity "user")
   (Thread/sleep 3000))
 
+(deftest track
+  (metrics/track "event" "source" 1)
+  (Thread/sleep 3000))
+


### PR DESCRIPTION
To be able to track any kind of metric, this new `track` fn just
receives the event's name, source and value.
