### PR TITLE
Modify the `errors/error` fn to handle non exceptions values

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/analytics "1.9.1"
+(defproject clanhr/analytics "1.10.0"
   :description "ClanHR specific analytics"
   :url "https://github.com/clanhr/analytics"
   :license {:name "Eclipse Public License"

--- a/src/clanhr/analytics/errors.clj
+++ b/src/clanhr/analytics/errors.clj
@@ -28,12 +28,19 @@
   (println request)
   (exception ex request))
 
+(defn object->hash-map
+  [obj]
+  (cond-> obj
+    (not (map? obj)) {:info obj}))
+
 (defn error
   "Registers a specific error"
   ([e] (error e {} {}))
   ([e info] (error e info {}))
   ([e info user]
-   (exception (RuntimeException. e) info user)
+   (if (instance? Throwable e)
+     (exception (RuntimeException. e) info user)
+     (exception (ex-info "error" (object->hash-map e)) info user))
    (result/failure e)))
 
 (Thread/setDefaultUncaughtExceptionHandler

--- a/test/clanhr/analytics/errors_test.clj
+++ b/test/clanhr/analytics/errors_test.clj
@@ -1,5 +1,6 @@
 (ns clanhr.analytics.errors-test
   (:require [clojure.test :refer :all]
+            [result.core :as result]
             [clanhr.analytics.errors :as errors]))
 
 (deftest exception
@@ -12,4 +13,6 @@
                      :personal-data {:company "Company"}}))
 
 (deftest error
-  (errors/error "Some error"))
+  (testing "non exception instance"
+    (let [result (errors/error {})]
+      (is (result/failed? result)))))

--- a/test/clanhr/analytics/metrics_test.clj
+++ b/test/clanhr/analytics/metrics_test.clj
@@ -21,4 +21,3 @@
 (deftest track
   (metrics/track "event" "source" 1)
   (Thread/sleep 3000))
-


### PR DESCRIPTION
Motivation:
  We want to log some errors to bugsnag that are not exceptions

Modifications:
  Modify the `errors/error` fn to handle non exceptions values
